### PR TITLE
Fix bug that was stopping users from terminating their own sessions

### DIFF
--- a/ssm_session_policy.tf
+++ b/ssm_session_policy.tf
@@ -66,11 +66,11 @@ data "aws_iam_policy_document" "ssm_session_doc" {
       "ssm:TerminateSession",
     ]
     condition {
-      test     = "StringLike"
-      variable = "ssm:resourceTag/aws:ssmmessages:session-id"
+      test = "StringLike"
       values = [
         "&{aws:userid}*",
       ]
+      variable = "ssm:resourceTag/aws:ssmmessages:session-id"
     }
     resources = [
       "*",

--- a/ssm_session_policy.tf
+++ b/ssm_session_policy.tf
@@ -55,13 +55,25 @@ data "aws_iam_policy_document" "ssm_session_doc" {
     ]
   }
 
-  # Allow the user to terminate his or her own sessions
+  # Allow the user to terminate his or her own sessions.
+  #
+  # The correct way to allow (assume role) users to terminate their
+  # (and only their) sessions is described in Method 2 of this
+  # document:
+  # https://docs.aws.amazon.com/systems-manager/latest/userguide/getting-started-restrict-access-examples.html#restrict-access-example-user-sessions
   statement {
     actions = [
       "ssm:TerminateSession",
     ]
+    condition {
+      test     = "StringLike"
+      variable = "ssm:resourceTag/aws:ssmmessages:session-id"
+      values = [
+        "&{aws:userid}*",
+      ]
+    }
     resources = [
-      "arn:aws:ssm:${var.aws_region}:${local.this_account_id}:session/&{aws:username}-*",
+      "*",
     ]
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a bug that was stopping users from terminating their own SSM sessions.

## 💭 Motivation and context ##

Resolves #28.

The AWS-provided IAM policy variable `aws:username` has no value when the principal is an assumed role, as described [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable).  This is why the previous incarnation of the policy failed.

The correct way to allow (assume role) users to terminate their (and only their) sessions is a bit more complicated and is described in Method 2 of [this document](https://docs.aws.amazon.com/systems-manager/latest/userguide/getting-started-restrict-access-examples.html#restrict-access-example-user-sessions).

## 🧪 Testing ##

- All automated tests pass.
- I applied these changes to the Shared Services account in the COOL staging environment and verified that I was able to start and terminate sessions to my heart's delight.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Apply these changes to all the "static" COOL accounts (both production and staging).
